### PR TITLE
Improve protection

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -380,5 +380,6 @@ unset( $wgGroupPermissions['staff'] );
 $wgGroupPermissions['staff']['unblockable'] = false;
 $wgGroupPermissions['staff']['awardsmanage'] = false;
 $wgGroupPermissions['staff']['giftadmin'] = false;
+$wgImplicitGroups[] = 'staff';
 $wgShowExceptionDetails = true;
 $wgShowDBErrorBacktrace = true;

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -374,6 +374,8 @@ $wgRemoveGroups['bureaucrat'] = array( 'bot', 'sysop', 'bureaucrat' );
 $wgGroupsRemoveFromSelf['sysop'] = array( 'sysop' );
 $wgRestrictionLevels = array( '', 'user', 'bureaucrat', 'sysop', 'autoconfirmed', 'steward' );
 $wgRestrictionTypes = array( 'create', 'edit', 'move', 'upload', 'delete', 'protect' );
+$wgCascadingRestrictionLevels = array( 'bureaucrat', 'sysop', 'steward' );
+$wgSemiprotectedRestrictionLevels = array( 'user', 'autoconfirmed', );
 unset( $wgGroupPermissions['staff'] );
 $wgGroupPermissions['staff']['unblockable'] = false;
 $wgGroupPermissions['staff']['awardsmanage'] = false;


### PR DESCRIPTION
Allow bureaucrat and steward protection to cascade.
Set user protection as semi-protection.
Set unused staff group to implicit.