### PR TITLE
Allow email on talk and watch update.

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -39,8 +39,8 @@ $wgEnableEmail = true;
 $wgEnableUserEmail = true; # UPO
 $wgEmergencyContact = "noreply@testwiki.wiki";
 $wgPasswordSender = "noreply@testwiki.wiki";
-$wgEnotifUserTalk = false; # UPO
-$wgEnotifWatchlist = false; # UPO
+$wgEnotifUserTalk = true; # UPO
+$wgEnotifWatchlist = true; # UPO
 $wgEmailAuthentication = true;
 # MySQL specific settings
 $wgDBprefix = "mw_";


### PR DESCRIPTION
Disabling these options does not set the default, it disables the upo entirely. These options are not available in preferences because of them being set false here.