### PR TITLE
force 2FA for particular groups

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -596,6 +596,12 @@ $wgRCFeeds['irc'] = [
 	'omit_bots' => true,
 ];
 
+$wgOATHRequiredForGroups = [
+    'interface-admin',
+    'steward',
+    'sysadmin'
+];
+
 //Custom rate limits (specifically for badcaptcha)
 $wgRateLimits = [
 	// Page edits


### PR DESCRIPTION
In line with [this proposal](https://testwiki.wiki/wiki/Test_Wiki:Community_portal#2FA_recommendation/proposal), I believe enforcing 2FA for these groups would be a positive measure, as it would prevent users from disabling 2FA after being granted the right.